### PR TITLE
Add support for FIFO queues

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -8,8 +8,10 @@ to move deadletter queue messages back into the original queue.
 were successfully enqueued to the destination.
 * Messages are sent and received in batches for faster processing.
 * Progress indicator.
+* Friendly output and error message.
 * Queue name resolution. For ease of use, you only need to provide a queue name and not the full `arn` address.
-* Message Attributes are copied over. 
+* Message Attributes are copied over.
+* Support for FIFO queues. MessageGroupId and MessageDeduplicationId are copied over to the destination messages.
 
 ## Installation
 


### PR DESCRIPTION
- Requests additional metadata, messageGroupId and messageDeduplicationId needed for FIFO queues.
- If present, it will copy it over to the destination messages. 