### PR TITLE
added session.Option: AssumeRoleTokenProvider

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"github.com/apex/log/handlers/cli"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sqs"
 	"github.com/fatih/color"
@@ -47,8 +48,9 @@ func main() {
 	kingpin.Parse()
 
 	options := session.Options{
-		Profile:           *profile,
-		SharedConfigState: session.SharedConfigEnable,
+		Profile:                 *profile,
+		SharedConfigState:       session.SharedConfigEnable,
+		AssumeRoleTokenProvider: stscreds.StdinTokenProvider,
 	}
 
 	if region != nil {


### PR DESCRIPTION
When using with environment vairable `AWS_PROFILE` and `mfa_serial` in `.aws/config` I get the error:
```
   ⨯ err
%!(EXTRA session.AssumeRoleTokenProviderNotSetError=AssumeRoleTokenProviderNotSetError: assume role with MFA enabled, but AssumeRoleTokenProvider session option not set.)
   ⨯ Unable to create AWS session for region
```
Adding the `AssumeRoleTokenProvider: stscreds.StdinTokenProvider,` allows for input of mfa code and also works for non-mfa profiles.