### PR TITLE
Add support for a --endpoint, -e parameter

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -116,6 +116,7 @@ Flags:
   -s, --source=SOURCE            The source queue name to move messages from.
   -d, --destination=DESTINATION  The destination queue name to move messages to.
   -r, --region="us-west-2"       The AWS region for source and destination queues.
+  -e, --endpoint="https://..."   Use a specific endpoint in an AWS region. For more information see https://docs.aws.amazon.com/general/latest/gr/sqs-service.html
   -p, --profile=""               Use a specific profile from AWS credentials file.
   -l, --limit=0                  Limits total number of messages moved. No limit is set by default.
   -b, --batch=10                 The maximum number of messages to move at a time.

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ var (
 	sourceQueue      = kingpin.Flag("source", "The source queue name to move messages from.").Short('s').Required().String()
 	destinationQueue = kingpin.Flag("destination", "The destination queue name to move messages to.").Short('d').Required().String()
 	region           = kingpin.Flag("region", "The AWS region for source and destination queues.").Short('r').Default("").String()
+	endpoint         = kingpin.Flag("endpoint", "Use a specific endpoint in an AWS region.").Short('e').Default("").String()
 	profile          = kingpin.Flag("profile", "Use a specific profile from AWS credentials file.").Short('p').String()
 	limit            = kingpin.Flag("limit", "Limits total number of messages moved. No limit is set by default.").Short('l').Default("0").Int()
 	maxBatchSize     = kingpin.Flag("batch", "The maximum number of messages to move at a time").Short('b').Default("10").Int64()
@@ -52,8 +53,11 @@ func main() {
 	}
 
 	if region != nil {
-		options.Config = aws.Config{Region: aws.String(*region)}
+		options.Config.Region = aws.String(*region)
 	}
+
+	// Our default "" value uses the AWS auto generated value
+	options.Config.Endpoint = aws.String(*endpoint)
 
 	sess, err := session.NewSessionWithOptions(options)
 


### PR DESCRIPTION
This allows usage of the FPIS endpoints in a given region, or in my case allows using with a non AWS version of sqs I use for development - elasticmq.