### PR TITLE
Fix receive message error handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -203,15 +203,14 @@ func moveMessages(sourceQueueUrl string, destinationQueueUrl string, svc *sqs.SQ
 
 	for {
 		resp, err := svc.ReceiveMessage(params)
+		if err != nil {
+			logAwsError("Failed to receive messages", err)
+			return
+		}
 
 		if len(resp.Messages) == 0 || messagesProcessed == totalMessages {
 			fmt.Println()
 			log.Info(color.New(color.FgCyan).Sprintf("Done. Moved %s messages", strconv.Itoa(totalMessages)))
-			return
-		}
-
-		if err != nil {
-			logAwsError("Failed to receive messages", err)
 			return
 		}
 


### PR DESCRIPTION
```go
len(resp.Messages) == 0
```
will be always true if an error occurred, that's why we need to check the error before