### PR TITLE
build: bump to use go1.17

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/tj/go v1.8.7
 	github.com/tj/go-progress v0.0.0-20180508172012-fadc638a53dd
-	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,14 @@ require (
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
 	github.com/apex/log v1.9.0
 	github.com/aws/aws-sdk-go v1.39.4
-	github.com/fatih/color v1.12.0
-	github.com/tj/go v1.8.7
-	github.com/tj/go-progress v0.0.0-20180508172012-fadc638a53dd
-	gopkg.in/alecthomas/kingpin.v2 v2.2.6
-)
-
-require (
 	github.com/buger/goterm v0.0.0-20181115115552-c206103e1f37 // indirect
+	github.com/fatih/color v1.12.0
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/tj/go v1.8.7
+	github.com/tj/go-progress v0.0.0-20180508172012-fadc638a53dd
 	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercury2269/sqsmover
 
-go 1.16
+go 1.17
 
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
@@ -11,4 +11,13 @@ require (
 	github.com/tj/go v1.8.7
 	github.com/tj/go-progress v0.0.0-20180508172012-fadc638a53dd
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
+)
+
+require (
+	github.com/buger/goterm v0.0.0-20181115115552-c206103e1f37 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	golang.org/x/sys v0.0.0-20210423082822-04245dca01da // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -102,6 +102,8 @@ golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da h1:b3NXsE2LusjYGGjL5bxEVZZORm/YEFFrWFjR8eFrw/c=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c h1:Lyn7+CqXIiC+LOR9aHD6jDK+hPcmAuCfuXztd1v4w1Q=
+golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=


### PR DESCRIPTION
Update to the [latest go1.17](https://blog.golang.org/go1.17)

---

relates to Homebrew/homebrew-core#83413

cc @mercury2269 