### PR TITLE
Remove unnecessary branching

### DIFF
--- a/main.go
+++ b/main.go
@@ -149,21 +149,13 @@ func logAwsError(message string, err error) {
 func convertToEntries(messages []*sqs.Message) []*sqs.SendMessageBatchRequestEntry {
 	result := make([]*sqs.SendMessageBatchRequestEntry, len(messages))
 	for i, message := range messages {
-		requestEntry := &sqs.SendMessageBatchRequestEntry{
-			MessageBody:       message.Body,
-			Id:                message.MessageId,
-			MessageAttributes: message.MessageAttributes,
+		result[i] = &sqs.SendMessageBatchRequestEntry{
+			MessageBody:            message.Body,
+			Id:                     message.MessageId,
+			MessageAttributes:      message.MessageAttributes,
+			MessageGroupId:         message.Attributes[sqs.MessageSystemAttributeNameMessageGroupId],
+			MessageDeduplicationId: message.Attributes[sqs.MessageSystemAttributeNameMessageDeduplicationId],
 		}
-
-		if messageGroupId, ok := message.Attributes[sqs.MessageSystemAttributeNameMessageGroupId]; ok {
-			requestEntry.MessageGroupId = messageGroupId
-		}
-
-		if messageDeduplicationId, ok := message.Attributes[sqs.MessageSystemAttributeNameMessageDeduplicationId]; ok {
-			requestEntry.MessageDeduplicationId = messageDeduplicationId
-		}
-
-		result[i] = requestEntry
 	}
 
 	return result


### PR DESCRIPTION
Because of how Go's missing-map-keys and zero value features work together, the branches for handling MessageGroupId and MessageDeduplicationId don't achieve anything that the language doesn't give us for free (using much less code).

This is a transparent (semantically identical) change.