### PR TITLE
deps: bump to use go1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.18
+        go-version-file: go.mod
     - name: Build
       run: go build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: runner / golangci-lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2
       with:
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: golint
         uses: reviewdog/action-golangci-lint@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
       - name: errcheck
         uses: reviewdog/action-golangci-lint@v2
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mercury2269/sqsmover
 
-go 1.18
+go 1.21
 
 require (
 	github.com/apex/log v1.9.0
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/color v1.12.0
 	github.com/tj/go v1.8.7
 	github.com/tj/go-progress v0.0.0-20180508172012-fadc638a53dd
+	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 )
 
@@ -19,5 +20,4 @@ require (
 	github.com/mattn/go-colorable v0.1.8 // indirect
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c // indirect
 )


### PR DESCRIPTION
- bump to use go1.21
- also update action versions (mostly related to nodejs 16 runtime)